### PR TITLE
Update site navigation to point to 5 drought events

### DIFF
--- a/src/components/DroughtHistory.vue
+++ b/src/components/DroughtHistory.vue
@@ -141,7 +141,7 @@ export default {
         const scrollLength =  scrollDistance/scrollSpeed;
         
         // scroll to position of specified drought
-        this.$gsap.to(window, {duration: scrollLength, scrollTo:"#scrollStop-" + scrollDroughtYear});
+        this.$gsap.to(window, {duration: scrollLength, scrollTo: {y: "#scrollStop-" + scrollDroughtYear, offsetY: 100}});
       },
       addOverlay() {
         const self = this;

--- a/src/components/DroughtHistory.vue
+++ b/src/components/DroughtHistory.vue
@@ -193,7 +193,7 @@ export default {
         const yearFormat = this.d3.timeFormat("%Y")
         yAxisDom.selectAll('text')
           .attr("class", "yAxisText")
-          .attr("id", function(i) {return "tick-" + yearFormat(i)});
+          .attr("id", function(d) {return "tick-" + yearFormat(d)});
         
         yAxisDom.selectAll(".tick line")
           .attr("class", "yAxisTick")

--- a/src/components/DroughtHistory.vue
+++ b/src/components/DroughtHistory.vue
@@ -190,8 +190,10 @@ export default {
           .attr("transform", "translate(" + yAxisOffset + ",0)")
 
         // set up classes for styling
+        const yearFormat = this.d3.timeFormat("%Y")
         yAxisDom.selectAll('text')
           .attr("class", "yAxisText")
+          .attr("id", function(i) {return "tick-" + yearFormat(i)});
         
         yAxisDom.selectAll(".tick line")
           .attr("class", "yAxisTick")

--- a/src/components/DroughtHistory.vue
+++ b/src/components/DroughtHistory.vue
@@ -193,7 +193,7 @@ export default {
         const yearFormat = this.d3.timeFormat("%Y")
         yAxisDom.selectAll('text')
           .attr("class", "yAxisText")
-          .attr("id", function(d) {return "tick-" + yearFormat(d)});
+          .attr("id", (d) => "tick-" + yearFormat(d));
         
         yAxisDom.selectAll(".tick line")
           .attr("class", "yAxisTick")

--- a/src/components/DroughtHistory.vue
+++ b/src/components/DroughtHistory.vue
@@ -197,6 +197,7 @@ export default {
           .attr("height", (d) => {
             return yScale(new Date(d.end)) - yScale(new Date(d.start))
           })
+          .attr("rx", 5)
           .attr("fill", "#F1F1F1") // fill in light grey so drought events highlighted
           .attr("opacity", 1)
         

--- a/src/components/DroughtHistory.vue
+++ b/src/components/DroughtHistory.vue
@@ -306,8 +306,8 @@ export default {
             scrollTrigger: {
               markers: false,
               trigger: `#${scrollIDFull}`,
-              start: "top 15%",
-              end: 'bottom 15%',
+              start: "top 25%",
+              end: 'bottom 25%',
               toggleClass: {targets: `#button-${scrollID}`, className:"currentButton"}, // adds class to target when triggered
               toggleActions: "restart reverse none reverse" 
             },

--- a/src/components/DroughtHistory.vue
+++ b/src/components/DroughtHistory.vue
@@ -204,28 +204,6 @@ export default {
           .domain([0,100])
           .range([0, this.overlayWidth])
 
-        // Add hidden timeline elements (only used to determine scroll distance)
-        const timelineYearStart = timelineDates[0].split('-')[0]
-        const timelineYearEnd = timelineDates[1].split('-')[0]
-        const timelineLengthInYears = timelineYearEnd - timelineYearStart;
-        const startMonthDay = '-' + timelineDates[0].split('-')[1] + '-' + timelineDates[0].split('-')[2]
-        const timelineYears = Array(timelineLengthInYears).fill().map((element, index) => index + Number(timelineYearStart))
-        const timelineYearRects = this.svgChartDynamic.selectAll('timelineYear')
-          .data(timelineYears)
-          .enter()
-          .append('rect')
-          .attr("id", d => "timelineYear-" + d)
-          .attr("class", "timelineYear")
-          .attr("x", yAxisOffset)
-          .attr("y", d => yScale(new Date(d + startMonthDay)))
-          .attr("width", this.overlayWidth - yAxisOffset)
-          .attr("height", (d,i) => {
-            return i===timelineYears.length-1 ? 
-              yScale(new Date(timelineDates[1])) - yScale(new Date(d + startMonthDay)) : 
-              yScale(new Date(timelineYears[i+1] + startMonthDay)) - yScale(new Date(d + startMonthDay))
-          })
-          .attr("opacity", 0) // make fully transparent
-
         // Add scroll to elements (only used for scroll navigation)
         const scrollToSpot = this.svgChartDynamic.selectAll('scrollToSpot')
           .data(this.scrollToDates)

--- a/src/components/DroughtHistory.vue
+++ b/src/components/DroughtHistory.vue
@@ -90,7 +90,6 @@ export default {
         mobileView: isMobile, // test for mobile
         annotations: droughtAnnotations.timelineEvents,
         scrollToDates:  null,
-        droughtIDs: null,
         // dimensions
         overlayWidth: null,
         overlayHeight: null
@@ -108,8 +107,6 @@ export default {
       {id: '1962', name: '1960s Drought', start: '1962-12-01', end: '1968-10-31'}, 
       {id: '1987', name: '1980s Drought', start: '1987-05-01', end: '1992-10-31'},
       {id: '1999', name: 'Turn-of-the-Century Drought', start: '1999-09-01', end: '2015-09-30'}]
-    // Get all possible button ids
-    this.droughtIDs = this.scrollToDates.map(scrollDate => scrollDate.id);
 
     // sort annotations
     this.annotations.sort((a,b) => this.d3.ascending(a.date, b.date))

--- a/src/components/DroughtHistory.vue
+++ b/src/components/DroughtHistory.vue
@@ -509,11 +509,12 @@ $writeFont: 'Nanum Pen Script', cursive;
 }
 #inset-map {
   position: sticky;
-  top: 50px;
+  top: 55px;
   height: 150px;
   filter: url(#shadow2);
   @media only screen and (max-width: 600px) {
     height: 75px;
+    top: 75px;
   }
 }
 #chart-container {

--- a/src/components/DroughtHistory.vue
+++ b/src/components/DroughtHistory.vue
@@ -272,13 +272,11 @@ export default {
         // Select dynamically added chart overlay svg
         const dynamicSVG = document.querySelector("#svg-dynamic");
 
-        // Add year in view animations, so that we know which years are in the current view
-        const yearTriggers = this.$gsap.utils.toArray(".timelineYear")
-        yearTriggers.forEach((yearTrigger) => {
-
+        // Add in view animations to tick marks, so that we know which years are in the current view
+        const tickMarkTriggers = this.$gsap.utils.toArray(".yAxisText")
+        tickMarkTriggers.forEach((tickMarkTrigger) => {
           // get unique ID for scroll step.
-          let scrollIDFull = yearTrigger.id
-          let scrollID = scrollIDFull.split('-')[1]
+          let scrollIDFull = tickMarkTrigger.id
 
           // When each year is in view on the timeline, add 'inView' class to element
           // NOTE: no visual change - simply for use in scrollTimeline()

--- a/src/components/DroughtHistory.vue
+++ b/src/components/DroughtHistory.vue
@@ -176,9 +176,31 @@ export default {
           .domain([new Date(timelineDates[0]), new Date(timelineDates[1])])
           .range([0, this.overlayHeight]);
 
-        // set up y axis
+        // set y-axis offset
         const yAxisOffset = this.mobileView ? 40: 45;
 
+        // Set up linear scale for chart width
+        const xScale = this.d3.scaleLinear()
+          .domain([0,100])
+          .range([0, this.overlayWidth])
+
+        // Add scroll to elements (only used for scroll navigation)
+        const scrollToSpot = this.svgChartDynamic.selectAll('scrollToSpot')
+          .data(this.scrollToDates)
+          .enter()
+          .append('rect')
+          .attr("id", d => "scrollStop-" + d.id)
+          .attr("class", "scrollToSpot")
+          .attr("x", yAxisOffset)
+          .attr("y", d => yScale(new Date(d.start)))
+          .attr("width", this.overlayWidth - yAxisOffset)
+          .attr("height", (d) => {
+            return yScale(new Date(d.end)) - yScale(new Date(d.start))
+          })
+          .attr("fill", "#F1F1F1") // fill in light grey so drought events highlighted
+          .attr("opacity", 1)
+        
+        // Add y axis
         const yAxis = this.d3.axisLeft(yScale)
           .ticks(this.d3.timeYear.every(1))
           .tickSize(-this.overlayWidth-yAxisOffset) // ticks spanning width of chart

--- a/src/components/DroughtHistory.vue
+++ b/src/components/DroughtHistory.vue
@@ -223,25 +223,6 @@ export default {
         // remove y axis line
         yAxisDom.select(".domain").remove()
 
-        // Set up linear scale for chart width
-        const xScale = this.d3.scaleLinear()
-          .domain([0,100])
-          .range([0, this.overlayWidth])
-
-        // Add scroll to elements (only used for scroll navigation)
-        const scrollToSpot = this.svgChartDynamic.selectAll('scrollToSpot')
-          .data(this.scrollToDates)
-          .enter()
-          .append('rect')
-          .attr("id", d => "scrollStop-" + d.id)
-          .attr("class", "scrollToSpot")
-          .attr("x", yAxisOffset)
-          .attr("y", d => yScale(new Date(d.start)))
-          .attr("width", this.overlayWidth - yAxisOffset)
-          .attr("height", (d) => {
-            return yScale(new Date(d.end)) - yScale(new Date(d.start))
-          })
-          .attr("opacity", 0) // make fully transparent
         // Set up annotations
         if (this.mobileView === false) {
           // On desktop, place annotations as text


### PR DESCRIPTION
This PR updates the site 'scroll-to' navigation to point to 5 specific drought events, rather than each decade of the timeline.

### To test
Pull changes locally, then run `npm run serve`

### Changes
* Update `this.scrollToDates` to include only the 5 drought events, listing start and end dates
* Use `this.scrollToDates` to populate button container, in place of `decadeIDs`
* `addOverlay()`:
  * Update `y` and `height` of `scrollToSpot` rectangles to reflect start and end dates of drought periods
  * ~Add hidden timeline elements for each year of the timeline~ _Add ids with the year to each y-axis tick mark text element_
    * These are added because the `scrollToSpot` rectangles no longer cover the full timeline, which means if we're not currently in one of the 5 drought period and no button is highlighted, we have no way of knowing our starting position in `scrollTimeline()`. I tried to find a better `gsap` alternative to pull current position, but wasn't finding anything.
    * Triggers are added to ~these~ _the y axis text_ elements in `addAnimations()` to indicate which years are in view. This information is used in `scrollTimeline()` to determine the scroll distance.
* `addAnimations()`:
  *  Add triggers to ~hidden timeline~ _y axis text_ elements to note which are in view at any given time
  * Simplify trigger for drought events that trigger styling of buttons at top, since no button should be highlighted on page load 
* `scrollTimeline()`:
  * Use currently in view ~hidden timeline~ _y axis text_ elements to determine where we are on the page currently, in order to compute `scrollDistance` and `scrollLength`

### Notes
* May want to adjust styling of buttons, since no button is highlighted on page load, and might not be obvious they are buttons?
* may need to adjust `scrollTimeline()` again depending on how we set up the lower section of the page